### PR TITLE
timezone-aware datetime object conversion fix

### DIFF
--- a/docs/features.ipynb
+++ b/docs/features.ipynb
@@ -16,7 +16,7 @@
     "- a way to further work with the summary statistics, by returning them as a dictionary\n",
     "- a way to clean up messy column names in both **pandas** and **Polars** dataframes\n",
     "\n",
-    "When using **skimpy**, please be aware that *numerical columns are rounded to 4 significant figures*.\n",
+    "When using **skimpy**, please be aware that *numerical columns are rounded to 4 significant figures*. You should also be aware that *any timezone-aware datetimes are converted into their naive equivalents*.\n",
     "\n",
     "You can find a full guide to the API on the [reference pages](reference/index.qmd)."
    ]
@@ -158,7 +158,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.8 ('.venv': poetry)",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -173,11 +173,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.10.12"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "40632773287a790210327f0a4164f429b4430d796dff9694a1110ee4b5468ac6"
-   }
   }
  },
  "nbformat": 4,

--- a/src/skimpy/__init__.py
+++ b/src/skimpy/__init__.py
@@ -121,6 +121,9 @@ def _infer_datatypes(df: pd.DataFrame) -> pd.DataFrame:
         elif col[1] == "timedelta64":
             data_type = "timedelta64[ns]"
         elif col[1] == "datetime64":
+            if pd.api.types.is_datetime64tz_dtype(df[col[0]]):
+                # Convert timezone-aware to timezone-naive
+                df[col[0]] = df[col[0]].dt.tz_localize(None)
             data_type = "datetime64[ns]"
         elif col[1] == "categorical":
             data_type = "category"

--- a/src/skimpy/__init__.py
+++ b/src/skimpy/__init__.py
@@ -121,7 +121,7 @@ def _infer_datatypes(df: pd.DataFrame) -> pd.DataFrame:
         elif col[1] == "timedelta64":
             data_type = "timedelta64[ns]"
         elif col[1] == "datetime64":
-            if pd.api.types.is_datetime64tz_dtype(df[col[0]]):
+            if isinstance(df[col[0]].dtype, pd.DatetimeTZDtype):
                 # Convert timezone-aware to timezone-naive
                 df[col[0]] = df[col[0]].dt.tz_localize(None)
             data_type = "datetime64[ns]"


### PR DESCRIPTION
Implement check and handling for timezone-aware datetime objects, converting them to timezone-naive for the .astype() numpy conversion function to work properly and not throw a TypeError if the dataframe has any timezone-aware datetime objects.

**The issue is attempted conversion via numpy's .astype() function** via ```df[col[0]] = df[col[0]].astype(data_type)``` with ```"datetime64[ns]"``` as the data type on datetime objects with a timezone.

Numpy will throw the below error if there are any timezone-aware datetime objects in the dataframe:

```
TypeError: Cannot use .astype to convert from timezone-aware dtype to timezone-naive dtype. Use obj.tz_localize(None) or obj.tz_convert('UTC').tz_localize(None) instead.
```

The proposed fix allows the dataframe to have timezone-aware datetime objects and still use skimpy to visualize the data analysis.

This can be tested with dummy data such as below:

```py
import pandas as pd
from datetime import datetime
import pytz

# Sample data
data = {
    "timezone_aware": [pd.Timestamp(datetime.now(), tz=pytz.UTC)],
    "timezone_naive": [pd.Timestamp(datetime.now())],
    "integer_col": [1],
}

df = pd.DataFrame(data)

skim(df)
```